### PR TITLE
Fix memory leak in NSURLSession by invalidating the session when it’s done

### DIFF
--- a/EventSource/EventSource.m
+++ b/EventSource/EventSource.m
@@ -229,6 +229,8 @@ didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSe
     self.eventSourceTask = [session dataTaskWithRequest:request];
     [self.eventSourceTask resume];
 
+    [session finishTasksAndInvalidate];
+    
     Event *e = [Event new];
     e.readyState = kEventStateConnecting;
 


### PR DESCRIPTION
This fix is for https://github.com/neilco/EventSource/issues/17