### PR TITLE
Memory leak fix

### DIFF
--- a/EventSource/EventSource.h
+++ b/EventSource/EventSource.h
@@ -41,6 +41,7 @@ typedef void (^EventSourceEventHandler)(Event *event);
 
 /// Connect to and receive Server-Sent Events (SSEs).
 @interface EventSource : NSObject
+@property (nonatomic, strong) NSURLSessionDataTask *eventSourceTask;
 
 /// Returns a new instance of EventSource with the specified URL.
 ///


### PR DESCRIPTION
Real fix for memory leak. The problem used to happen when sending several requests and then trying to release the variable. Now it works much better without that problem..